### PR TITLE
Add version info to health endpoint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,12 +49,16 @@ arch = 386
 build_dir = linux_${arch}
 service_name = homebugh-api
 
+current_time = $(shell date +%Y-%m-%dT%H:%M:%S%z)
+git_description = $(shell git describe --always --dirty --tags --long)
+linker_flags = "-s -X 'main.buildTime=${current_time}' -X 'main.build=${git_description}'"
+
 ## build/api: build the cmd/api application
 .PHONY: build/api
 build/api:
 	@echo 'Building cmd/api...'
-	go build -o=./bin/${service_name} ./cmd/api
-	GOOS=linux GOARCH=${arch} go build -o=./bin/${build_dir}/${service_name} ./cmd/api
+	go build -ldflags=${linker_flags} -o=./bin/${service_name} ./cmd/api
+	GOOS=linux GOARCH=${arch} go build -ldflags=${linker_flags} -o=./bin/${build_dir}/${service_name} ./cmd/api
 
 
 # =========================================================================== #

--- a/cmd/api/health.go
+++ b/cmd/api/health.go
@@ -4,7 +4,9 @@ import "net/http"
 
 func (app *application) healthHandler(w http.ResponseWriter, r *http.Request) {
 	env := envelope{
-		"status": "OK",
+		"status":    "OK",
+		"version":   app.metadata.version,
+		"buildTime": app.metadata.buildTime,
 	}
 
 	err := app.writeJSON(w, http.StatusOK, env, nil)

--- a/cmd/api/health_test.go
+++ b/cmd/api/health_test.go
@@ -8,7 +8,12 @@ import (
 )
 
 func TestHealthHandler(t *testing.T) {
-	app := application{}
+	app := application{
+		metadata: appMetadata{
+			version:   "0.0.1+test",
+			buildTime: "2021-09-06T14:40:56+0200",
+		},
+	}
 
 	ts := httptest.NewTLSServer(app.routes())
 	defer ts.Close()
@@ -28,7 +33,7 @@ func TestHealthHandler(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	wantBody := `{"status":"OK"}`
+	wantBody := `{"buildTime":"2021-09-06T14:40:56+0200","status":"OK","version":"0.0.1+test"}`
 	if string(body) != wantBody {
 		t.Errorf("want body to be equal to `%q`; got `%q`", wantBody, string(body))
 	}

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -14,8 +14,21 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
+const version = "0.0.1"
+
+var (
+	build     string
+	buildTime string
+)
+
+type appMetadata struct {
+	version   string
+	buildTime string
+}
+
 type application struct {
 	environment string
+	metadata    appMetadata
 	models      models.Models
 }
 
@@ -48,6 +61,10 @@ func main() {
 
 	app := &application{
 		environment: env,
+		metadata: appMetadata{
+			version:   fmt.Sprintf("%s+%s", version, build),
+			buildTime: buildTime,
+		},
 		models: models.Models{
 			Users:        &mysql.UserModel{DB: db},
 			AuthSessions: &mysql.AuthSessionModel{DB: db},
@@ -67,8 +84,10 @@ func main() {
 	}
 
 	fmt.Println()
-	fmt.Printf("The application starting in %s\n", env)
-	fmt.Printf("Listening on %s, CTRL+C to stop\n", srv.Addr)
+	fmt.Printf("The application starting in %s\n\n", env)
+	fmt.Printf("Version:\t%s\n", app.metadata.version)
+	fmt.Printf("Build time:\t%s\n", app.metadata.buildTime)
+	fmt.Printf("\nListening on %s, CTRL+C to stop\n", srv.Addr)
 	err = srv.ListenAndServeTLS(cfg.TLS.CertPemFile, cfg.TLS.KeyPemFile)
 	if err != nil {
 		fmt.Println(err)

--- a/cmd/api/middleware.go
+++ b/cmd/api/middleware.go
@@ -37,7 +37,7 @@ func (app *application) rateLimit(next http.Handler) http.Handler {
 	}()
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if app.environment == "production" {
+		if app.metadata.environment == "production" {
 			ip := realip.FromRequest(r)
 
 			mu.Lock()


### PR DESCRIPTION
Display version metadata when:

* The app starts
* `version` flag requested
* `/health` endpoint fetched