### PR TITLE
Add accounts endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All the changes to the project are documented in this file.
+
+## [Unreleased]
+
+## [0.1.0] - 2021-09-09
+### Added
+
+* `/accounts` endpoint to fetch information about accounts https://github.com/ck3g/homebugh-api/pull/18
+
+## [0.0.1] - 2021-08-27
+## Added
+
+* `/categories` endpoint to fetch information about categories https://github.com/ck3g/homebugh-api/pull/13

--- a/cmd/api/accounts.go
+++ b/cmd/api/accounts.go
@@ -1,0 +1,17 @@
+package main
+
+import "net/http"
+
+func (app *application) accountsHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Add("Vary", "Authorization")
+
+	env := envelope{
+		"accounts": []string{},
+	}
+
+	err := app.writeJSON(w, http.StatusOK, env, nil)
+	if err != nil {
+		app.serverErrorResponse(w, r, err)
+		return
+	}
+}

--- a/cmd/api/accounts.go
+++ b/cmd/api/accounts.go
@@ -1,15 +1,38 @@
 package main
 
-import "net/http"
+import (
+	"net/http"
+	"strings"
+)
 
 func (app *application) accountsHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Add("Vary", "Authorization")
+
+	// TODO: extract into middleware
+	authorizationHeader := r.Header.Get("Authorization")
+	if authorizationHeader == "" {
+		app.invalidAuthenticationTokenResponse(w, r)
+		return
+	}
+
+	headerParts := strings.Split(authorizationHeader, " ")
+	if len(headerParts) != 2 || headerParts[0] != "Bearer" {
+		app.invalidAuthenticationTokenResponse(w, r)
+		return
+	}
+
+	token := headerParts[1]
+	_, err := app.models.AuthSessions.GetByToken(token)
+	if err != nil {
+		app.invalidAuthenticationTokenResponse(w, r)
+		return
+	}
 
 	env := envelope{
 		"accounts": []string{},
 	}
 
-	err := app.writeJSON(w, http.StatusOK, env, nil)
+	err = app.writeJSON(w, http.StatusOK, env, nil)
 	if err != nil {
 		app.serverErrorResponse(w, r, err)
 		return

--- a/cmd/api/accounts_test.go
+++ b/cmd/api/accounts_test.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestAccountsHandler(t *testing.T) {
+	app := application{}
+
+	ts := httptest.NewTLSServer(app.routes())
+	defer ts.Close()
+
+	tests := []struct {
+		name           string
+		token          string
+		wantStatusCode int
+		wantBody       []byte
+	}{
+		{
+			name:           "With valid token",
+			token:          "Bearer valid-token",
+			wantStatusCode: http.StatusOK,
+			wantBody:       []byte(`{"accounts":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req, err := http.NewRequest("GET", ts.URL+"/accounts", nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			req.Header.Set("Authorization", tt.token)
+			c := ts.Client()
+			rs, err := c.Do(req)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if rs.StatusCode != tt.wantStatusCode {
+				t.Errorf("want status %d; got %d", tt.wantStatusCode, rs.StatusCode)
+			}
+
+			defer rs.Body.Close()
+			body, err := ioutil.ReadAll(rs.Body)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if string(body) != string(tt.wantBody) {
+				t.Errorf("want body to be equal to `%q`; got `%q`", tt.wantBody, string(body))
+			}
+		})
+	}
+}

--- a/cmd/api/accounts_test.go
+++ b/cmd/api/accounts_test.go
@@ -5,10 +5,17 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/ck3g/homebugh-api/pkg/models"
+	"github.com/ck3g/homebugh-api/pkg/models/mock"
 )
 
 func TestAccountsHandler(t *testing.T) {
-	app := application{}
+	app := application{
+		models: models.Models{
+			AuthSessions: &mock.AuthSessionModel{},
+		},
+	}
 
 	ts := httptest.NewTLSServer(app.routes())
 	defer ts.Close()
@@ -24,6 +31,24 @@ func TestAccountsHandler(t *testing.T) {
 			token:          "Bearer valid-token",
 			wantStatusCode: http.StatusOK,
 			wantBody:       []byte(`{"accounts":[]}`),
+		},
+		{
+			name:           "with blank token",
+			token:          "",
+			wantStatusCode: http.StatusUnauthorized,
+			wantBody:       []byte(`{"error":"invalid or missing authentication token"}`),
+		},
+		{
+			name:           "with non-bearer token",
+			token:          "Notbearer valid-token",
+			wantStatusCode: http.StatusUnauthorized,
+			wantBody:       []byte(`{"error":"invalid or missing authentication token"}`),
+		},
+		{
+			name:           "with invalid token",
+			token:          "Bearer invalid-token",
+			wantStatusCode: http.StatusUnauthorized,
+			wantBody:       []byte(`{"error":"invalid or missing authentication token"}`),
 		},
 	}
 

--- a/cmd/api/accounts_test.go
+++ b/cmd/api/accounts_test.go
@@ -34,8 +34,12 @@ func TestAccountsHandler(t *testing.T) {
 			wantStatusCode: http.StatusOK,
 			wantBody: []byte(
 				`{"accounts":[` +
-					`{"id":1,"name":"Bank","balance":1000,"currency_id":1,"status":"active","show_in_summary":true},` +
-					`{"id":2,"name":"Cash","balance":100.5,"currency_id":1,"status":"active","show_in_summary":true}],` +
+					`{"id":1,"name":"Bank","balance":1000,` +
+					`"currency":{"id":1,"name":"Euro","unit":"€"},` +
+					`"status":"active","show_in_summary":true},` +
+					`{"id":2,"name":"Cash","balance":100.5,` +
+					`"currency":{"id":1,"name":"Euro","unit":"€"},` +
+					`"status":"active","show_in_summary":true}],` +
 					`"metadata":{"current_page":1,"page_size":20,"first_page":1,"last_page":1,"total_records":2}}`),
 		},
 		{
@@ -44,8 +48,12 @@ func TestAccountsHandler(t *testing.T) {
 			wantStatusCode: http.StatusOK,
 			wantBody: []byte(
 				`{"accounts":[` +
-					`{"id":3,"name":"Bank","balance":500,"currency_id":1,"status":"active","show_in_summary":true},` +
-					`{"id":4,"name":"Cash","balance":30.5,"currency_id":1,"status":"active","show_in_summary":true}],` +
+					`{"id":3,"name":"Bank","balance":500,` +
+					`"currency":{"id":1,"name":"Euro","unit":"€"},` +
+					`"status":"active","show_in_summary":true},` +
+					`{"id":4,"name":"Cash","balance":30.5,` +
+					`"currency":{"id":1,"name":"Euro","unit":"€"},` +
+					`"status":"active","show_in_summary":true}],` +
 					`"metadata":{"current_page":1,"page_size":20,"first_page":1,"last_page":1,"total_records":2}}`),
 		},
 		{

--- a/cmd/api/accounts_test.go
+++ b/cmd/api/accounts_test.go
@@ -13,7 +13,9 @@ import (
 func TestAccountsHandler(t *testing.T) {
 	app := application{
 		models: models.Models{
+			Accounts:     &mock.AccountModel{},
 			AuthSessions: &mock.AuthSessionModel{},
+			Users:        &mock.UserModel{},
 		},
 	}
 
@@ -30,7 +32,21 @@ func TestAccountsHandler(t *testing.T) {
 			name:           "With valid token",
 			token:          "Bearer valid-token",
 			wantStatusCode: http.StatusOK,
-			wantBody:       []byte(`{"accounts":[]}`),
+			wantBody: []byte(
+				`{"accounts":[` +
+					`{"id":1,"name":"Bank","balance":1000,"currency_id":1,"status":"active","show_in_summary":true},` +
+					`{"id":2,"name":"Cash","balance":100.5,"currency_id":1,"status":"active","show_in_summary":true}],` +
+					`"metadata":{"current_page":1,"page_size":20,"first_page":1,"last_page":1,"total_records":2}}`),
+		},
+		{
+			name:           "With valid token of second user",
+			token:          "Bearer valid-token-2",
+			wantStatusCode: http.StatusOK,
+			wantBody: []byte(
+				`{"accounts":[` +
+					`{"id":3,"name":"Bank","balance":500,"currency_id":1,"status":"active","show_in_summary":true},` +
+					`{"id":4,"name":"Cash","balance":30.5,"currency_id":1,"status":"active","show_in_summary":true}],` +
+					`"metadata":{"current_page":1,"page_size":20,"first_page":1,"last_page":1,"total_records":2}}`),
 		},
 		{
 			name:           "with blank token",
@@ -77,7 +93,7 @@ func TestAccountsHandler(t *testing.T) {
 			}
 
 			if string(body) != string(tt.wantBody) {
-				t.Errorf("want body to be equal to `%q`; got `%q`", tt.wantBody, string(body))
+				t.Errorf("want body to be equal to \n`%q`\ngot \n`%q`\n", tt.wantBody, string(body))
 			}
 		})
 	}

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -73,9 +73,10 @@ func main() {
 	app := &application{
 		metadata: metadata,
 		models: models.Models{
-			Users:        &mysql.UserModel{DB: db},
+			Accounts:     &mysql.AccountModel{DB: db},
 			AuthSessions: &mysql.AuthSessionModel{DB: db},
 			Categories:   &mysql.CategoryModel{DB: db},
+			Users:        &mysql.UserModel{DB: db},
 		},
 	}
 

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -14,7 +14,7 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-const version = "0.0.1"
+const version = "0.1.0"
 
 var (
 	build     string

--- a/cmd/api/routes.go
+++ b/cmd/api/routes.go
@@ -13,5 +13,7 @@ func (app *application) routes() http.Handler {
 
 	mux.HandleFunc("/categories", app.categoriesHandler)
 
+	mux.HandleFunc("/accounts", app.accountsHandler)
+
 	return app.rateLimit(mux)
 }

--- a/pkg/models/mock/accounts.go
+++ b/pkg/models/mock/accounts.go
@@ -1,0 +1,57 @@
+package mock
+
+import "github.com/ck3g/homebugh-api/pkg/models"
+
+type AccountModel struct{}
+
+var (
+	user1BankAccount = &models.Account{
+		ID:            1,
+		Name:          "Bank",
+		Balance:       1000,
+		CurrencyID:    1,
+		Status:        "active",
+		ShowInSummary: true,
+	}
+	user1CashAccount = &models.Account{
+		ID:            2,
+		Name:          "Cash",
+		Balance:       100.5,
+		CurrencyID:    1,
+		Status:        "active",
+		ShowInSummary: true,
+	}
+	user2BankAccount = &models.Account{
+		ID:            3,
+		Name:          "Bank",
+		Balance:       500,
+		CurrencyID:    1,
+		Status:        "active",
+		ShowInSummary: true,
+	}
+	user2CashAccount = &models.Account{
+		ID:            4,
+		Name:          "Cash",
+		Balance:       30.5,
+		CurrencyID:    1,
+		Status:        "active",
+		ShowInSummary: true,
+	}
+)
+
+func (m *AccountModel) All(userID int64, filters models.Filters) ([]*models.Account, models.Metadata, error) {
+	var accounts []*models.Account
+
+	switch userID {
+	case 1:
+		accounts = []*models.Account{user1BankAccount, user1CashAccount}
+	case 2:
+		accounts = []*models.Account{user2BankAccount, user2CashAccount}
+	default:
+		accounts = []*models.Account{}
+	}
+
+	metadata := models.CalculateMetadata(2, filters.CurrentPage(), filters.Limit())
+
+	return accounts, metadata, nil
+}

--- a/pkg/models/mock/accounts.go
+++ b/pkg/models/mock/accounts.go
@@ -5,11 +5,13 @@ import "github.com/ck3g/homebugh-api/pkg/models"
 type AccountModel struct{}
 
 var (
+	euro = models.Currency{ID: 1, Name: "Euro", Unit: "€"}
+
 	user1BankAccount = &models.Account{
 		ID:            1,
 		Name:          "Bank",
 		Balance:       1000,
-		CurrencyID:    1,
+		Currency:      euro,
 		Status:        "active",
 		ShowInSummary: true,
 	}
@@ -17,7 +19,7 @@ var (
 		ID:            2,
 		Name:          "Cash",
 		Balance:       100.5,
-		CurrencyID:    1,
+		Currency:      euro,
 		Status:        "active",
 		ShowInSummary: true,
 	}
@@ -25,7 +27,7 @@ var (
 		ID:            3,
 		Name:          "Bank",
 		Balance:       500,
-		CurrencyID:    1,
+		Currency:      euro,
 		Status:        "active",
 		ShowInSummary: true,
 	}
@@ -33,7 +35,7 @@ var (
 		ID:            4,
 		Name:          "Cash",
 		Balance:       30.5,
-		CurrencyID:    1,
+		Currency:      euro,
 		Status:        "active",
 		ShowInSummary: true,
 	}

--- a/pkg/models/mock/accounts.go
+++ b/pkg/models/mock/accounts.go
@@ -39,6 +39,10 @@ var (
 	}
 )
 
+func (m *AccountModel) Insert(name string, userID int64, currencyID int64, status string, showInSummary bool) (int64, error) {
+	return 5, nil
+}
+
 func (m *AccountModel) All(userID int64, filters models.Filters) ([]*models.Account, models.Metadata, error) {
 	var accounts []*models.Account
 

--- a/pkg/models/models.go
+++ b/pkg/models/models.go
@@ -30,6 +30,22 @@ type Models struct {
 	Categories   CategoryStorage
 }
 
+// Account represents a user's accounts
+type Account struct {
+	ID            int64   `json:"id"`
+	Name          string  `json:"name"`
+	Balance       float64 `json:"balance"`
+	CurrencyID    int64   `json:"currency_id"` // TODO: change to currency
+	Status        string  `json:"status"`
+	ShowInSummary bool    `json:"show_in_summary"`
+}
+
+// AccountStorate contains information about user's accounts
+type AccountStorage interface {
+	// Insert(name string, userID int64, currencyID int64, status string, showInSummary bool) (int64, error)
+	All(userID int64, filters Filters) ([]*Account, Metadata, error)
+}
+
 // AuthSession represents authentication session data
 type AuthSession struct {
 	ID        int64

--- a/pkg/models/models.go
+++ b/pkg/models/models.go
@@ -43,7 +43,7 @@ type Account struct {
 
 // AccountStorate contains information about user's accounts
 type AccountStorage interface {
-	// Insert(name string, userID int64, currencyID int64, status string, showInSummary bool) (int64, error)
+	Insert(name string, userID int64, currencyID int64, status string, showInSummary bool) (int64, error)
 	All(userID int64, filters Filters) ([]*Account, Metadata, error)
 }
 

--- a/pkg/models/models.go
+++ b/pkg/models/models.go
@@ -33,12 +33,12 @@ type Models struct {
 
 // Account represents a user's accounts
 type Account struct {
-	ID            int64   `json:"id"`
-	Name          string  `json:"name"`
-	Balance       float64 `json:"balance"`
-	CurrencyID    int64   `json:"currency_id"` // TODO: change to currency
-	Status        string  `json:"status"`
-	ShowInSummary bool    `json:"show_in_summary"`
+	ID            int64    `json:"id"`
+	Name          string   `json:"name"`
+	Balance       float64  `json:"balance"`
+	Currency      Currency `json:"currency"`
+	Status        string   `json:"status"`
+	ShowInSummary bool     `json:"show_in_summary"`
 }
 
 // AccountStorate contains information about user's accounts
@@ -84,6 +84,13 @@ type Category struct {
 type CategoryStorage interface {
 	Insert(name string, categoryType CategoryType, userID int64, inactive bool) (int64, error)
 	All(userID int64, filters Filters) ([]*Category, Metadata, error)
+}
+
+// Currency represents currencies model
+type Currency struct {
+	ID   int64  `json:"id"`
+	Name string `json:"name"`
+	Unit string `json:"unit"`
 }
 
 // User represents a user data

--- a/pkg/models/models.go
+++ b/pkg/models/models.go
@@ -25,9 +25,10 @@ var (
 )
 
 type Models struct {
-	Users        UserStorage
+	Accounts     AccountStorage
 	AuthSessions AuthSessionStorage
 	Categories   CategoryStorage
+	Users        UserStorage
 }
 
 // Account represents a user's accounts

--- a/pkg/models/mysql/accounts.go
+++ b/pkg/models/mysql/accounts.go
@@ -1,0 +1,68 @@
+package mysql
+
+import (
+	"database/sql"
+
+	"github.com/ck3g/homebugh-api/pkg/models"
+)
+
+type AccountModel struct {
+	DB *sql.DB
+}
+
+func (m *AccountModel) Insert(name string, userID int64, currencyID int64, status string, showInSummary bool) (int64, error) {
+	var id int64
+
+	query := `INSERT INTO accounts (name, user_id, currency_id, status, show_in_summary, created_at, updated_at)
+	VALUES (?, ?, ?, ?, ?, UTC_TIMESTAMP(), UTC_TIMESTAMP())`
+
+	args := []interface{}{name, userID, currencyID, status, showInSummary}
+	res, err := m.DB.Exec(query, args...)
+	if err != nil {
+		return id, err
+	}
+
+	id, err = res.LastInsertId()
+	if err != nil {
+		return id, err
+	}
+
+	return id, nil
+}
+
+func (m *AccountModel) All(userID int64, filters models.Filters) ([]*models.Account, models.Metadata, error) {
+	accounts := []*models.Account{}
+
+	query := `SELECT id, name, funds, currency_id, status, show_in_summary
+	FROM accounts
+	WHERE user_id = ?
+	ORDER BY id`
+
+	rows, err := m.DB.Query(query, userID)
+	if err != nil {
+		return accounts, models.Metadata{}, err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var account models.Account
+
+		err := rows.Scan(
+			&account.ID,
+			&account.Name,
+			&account.Balance,
+			&account.CurrencyID,
+			&account.Status,
+			&account.ShowInSummary,
+		)
+		if err != nil {
+			return accounts, models.Metadata{}, err
+		}
+
+		accounts = append(accounts, &account)
+	}
+
+	metadata := models.CalculateMetadata(1, filters.CurrentPage(), filters.Limit())
+
+	return accounts, metadata, nil
+}

--- a/pkg/models/mysql/accounts_test.go
+++ b/pkg/models/mysql/accounts_test.go
@@ -1,0 +1,56 @@
+package mysql
+
+import (
+	"testing"
+
+	"github.com/ck3g/homebugh-api/pkg/models"
+)
+
+func TestAccountInsert(t *testing.T) {
+	t.Run("successful insert", func(t *testing.T) {
+		db, teardown := newTestDB(t)
+		defer teardown()
+
+		accounts := &AccountModel{db}
+		id, err := accounts.Insert("Bank", 1, 1, "active", true)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		filters := models.Filters{
+			Page:     1,
+			PageSize: 20,
+		}
+
+		all, _, err := accounts.All(1, filters)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if len(all) != 1 {
+			t.Errorf("want 1 account; got %d", len(all))
+			return
+		}
+
+		account := all[0]
+		if account.ID != id {
+			t.Errorf("want ID %d; got %d", id, account.ID)
+		}
+
+		if account.Name != "Bank" {
+			t.Errorf("want Name %s; got %s", "Bank", account.Name)
+		}
+
+		if account.CurrencyID != 1 {
+			t.Errorf("want CurrencyID %d; got %d", 1, account.CurrencyID)
+		}
+
+		if account.Status != "active" {
+			t.Errorf("want status %s; got %s", "active", account.Status)
+		}
+
+		if !account.ShowInSummary {
+			t.Errorf("want show in summary %t; got %t", true, account.ShowInSummary)
+		}
+	})
+}

--- a/pkg/models/mysql/accounts_test.go
+++ b/pkg/models/mysql/accounts_test.go
@@ -54,3 +54,132 @@ func TestAccountInsert(t *testing.T) {
 		}
 	})
 }
+
+func TestAccountAll(t *testing.T) {
+	db, teardown := newTestDB(t)
+	defer teardown()
+
+	accounts := &AccountModel{db}
+
+	accountsData := map[int]struct {
+		name          string
+		userID        int64
+		currencyID    int64
+		status        string
+		showInSummary bool
+	}{
+		0: {"Bank", 1, 1, "active", true},
+		1: {"Bank", 2, 1, "active", true},
+		2: {"Cash", 1, 1, "active", true},
+	}
+	ids := map[int]int64{}
+
+	for i, a := range accountsData {
+		id, err := accounts.Insert(a.name, a.userID, a.currencyID, a.status, a.showInSummary)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		ids[i] = id
+	}
+
+	tests := []struct {
+		name             string
+		userID           int64
+		filters          models.Filters
+		wantCount        int
+		wantTotalRecords int
+		wantAccounts     []*models.Account
+	}{
+		{
+			name:             "successful fetch for specific user",
+			userID:           1,
+			filters:          models.Filters{Page: 1, PageSize: 20},
+			wantCount:        2,
+			wantTotalRecords: 2,
+			wantAccounts: []*models.Account{
+				{ID: ids[0], Name: "Bank", CurrencyID: 1, Status: "active", ShowInSummary: true},
+				{ID: ids[2], Name: "Cash", CurrencyID: 1, Status: "active", ShowInSummary: true},
+			},
+		},
+		{
+			name:             "accounts from the first page",
+			userID:           1,
+			filters:          models.Filters{Page: 1, PageSize: 1},
+			wantCount:        1,
+			wantTotalRecords: 2,
+			wantAccounts: []*models.Account{
+				{ID: ids[0], Name: "Bank", CurrencyID: 1, Status: "active", ShowInSummary: true},
+			},
+		},
+		{
+			name:             "accounts from the second page",
+			userID:           1,
+			filters:          models.Filters{Page: 2, PageSize: 1},
+			wantCount:        1,
+			wantTotalRecords: 2,
+			wantAccounts: []*models.Account{
+				{ID: ids[2], Name: "Cash", CurrencyID: 1, Status: "active", ShowInSummary: true},
+			},
+		},
+		{
+			name:             "accounts from the greater than last page",
+			userID:           1,
+			filters:          models.Filters{Page: 100, PageSize: 1},
+			wantCount:        0,
+			wantTotalRecords: 2,
+			wantAccounts:     []*models.Account{},
+		},
+		{
+			name:             "accounts from the negative page",
+			userID:           1,
+			filters:          models.Filters{Page: -1, PageSize: 1},
+			wantCount:        1,
+			wantTotalRecords: 2,
+			wantAccounts: []*models.Account{
+				{ID: ids[0], Name: "Bank", CurrencyID: 1, Status: "active", ShowInSummary: true},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			all, metadata, err := accounts.All(tt.userID, tt.filters)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if len(all) != tt.wantCount {
+				t.Errorf("want %d accounts; got %d", tt.wantCount, len(all))
+			}
+
+			if metadata.TotalRecords != tt.wantTotalRecords {
+				t.Errorf("want %d total records; got %d", tt.wantTotalRecords, metadata.TotalRecords)
+			}
+
+			for i, got := range all {
+				wantAccount := tt.wantAccounts[i]
+
+				if got.ID != wantAccount.ID {
+					t.Errorf("want ID %d; got %d", wantAccount.ID, got.ID)
+				}
+
+				if got.Name != wantAccount.Name {
+					t.Errorf("want Name %s; got %s", wantAccount.Name, got.Name)
+				}
+
+				if got.CurrencyID != wantAccount.CurrencyID {
+					t.Errorf("want CurrencyID %d; got %d", wantAccount.CurrencyID, got.CurrencyID)
+				}
+
+				if got.Status != wantAccount.Status {
+					t.Errorf("want Status %s; got %s", wantAccount.Status, got.Status)
+				}
+
+				if got.ShowInSummary != wantAccount.ShowInSummary {
+					t.Errorf("want ShowInSummary %t; got %t", wantAccount.ShowInSummary, got.ShowInSummary)
+				}
+			}
+		})
+	}
+}

--- a/pkg/models/mysql/accounts_test.go
+++ b/pkg/models/mysql/accounts_test.go
@@ -41,8 +41,8 @@ func TestAccountInsert(t *testing.T) {
 			t.Errorf("want Name %s; got %s", "Bank", account.Name)
 		}
 
-		if account.CurrencyID != 1 {
-			t.Errorf("want CurrencyID %d; got %d", 1, account.CurrencyID)
+		if account.Currency.ID != 1 {
+			t.Errorf("want CurrencyID %d; got %d", 1, account.Currency.ID)
 		}
 
 		if account.Status != "active" {
@@ -61,6 +61,7 @@ func TestAccountAll(t *testing.T) {
 
 	accounts := &AccountModel{db}
 
+	currency := models.Currency{ID: 1, Name: "Euro", Unit: "€"}
 	accountsData := map[int]struct {
 		name          string
 		userID        int64
@@ -68,9 +69,9 @@ func TestAccountAll(t *testing.T) {
 		status        string
 		showInSummary bool
 	}{
-		0: {"Bank", 1, 1, "active", true},
-		1: {"Bank", 2, 1, "active", true},
-		2: {"Cash", 1, 1, "active", true},
+		0: {"Bank", 1, currency.ID, "active", true},
+		1: {"Bank", 2, currency.ID, "active", true},
+		2: {"Cash", 1, currency.ID, "active", true},
 	}
 	ids := map[int]int64{}
 
@@ -98,8 +99,8 @@ func TestAccountAll(t *testing.T) {
 			wantCount:        2,
 			wantTotalRecords: 2,
 			wantAccounts: []*models.Account{
-				{ID: ids[0], Name: "Bank", CurrencyID: 1, Status: "active", ShowInSummary: true},
-				{ID: ids[2], Name: "Cash", CurrencyID: 1, Status: "active", ShowInSummary: true},
+				{ID: ids[0], Name: "Bank", Currency: currency, Status: "active", ShowInSummary: true},
+				{ID: ids[2], Name: "Cash", Currency: currency, Status: "active", ShowInSummary: true},
 			},
 		},
 		{
@@ -109,7 +110,7 @@ func TestAccountAll(t *testing.T) {
 			wantCount:        1,
 			wantTotalRecords: 2,
 			wantAccounts: []*models.Account{
-				{ID: ids[0], Name: "Bank", CurrencyID: 1, Status: "active", ShowInSummary: true},
+				{ID: ids[0], Name: "Bank", Currency: currency, Status: "active", ShowInSummary: true},
 			},
 		},
 		{
@@ -119,7 +120,7 @@ func TestAccountAll(t *testing.T) {
 			wantCount:        1,
 			wantTotalRecords: 2,
 			wantAccounts: []*models.Account{
-				{ID: ids[2], Name: "Cash", CurrencyID: 1, Status: "active", ShowInSummary: true},
+				{ID: ids[2], Name: "Cash", Currency: currency, Status: "active", ShowInSummary: true},
 			},
 		},
 		{
@@ -137,7 +138,7 @@ func TestAccountAll(t *testing.T) {
 			wantCount:        1,
 			wantTotalRecords: 2,
 			wantAccounts: []*models.Account{
-				{ID: ids[0], Name: "Bank", CurrencyID: 1, Status: "active", ShowInSummary: true},
+				{ID: ids[0], Name: "Bank", Currency: currency, Status: "active", ShowInSummary: true},
 			},
 		},
 	}
@@ -168,8 +169,16 @@ func TestAccountAll(t *testing.T) {
 					t.Errorf("want Name %s; got %s", wantAccount.Name, got.Name)
 				}
 
-				if got.CurrencyID != wantAccount.CurrencyID {
-					t.Errorf("want CurrencyID %d; got %d", wantAccount.CurrencyID, got.CurrencyID)
+				if got.Currency.ID != wantAccount.Currency.ID {
+					t.Errorf("want Currency.ID %d; got %d", wantAccount.Currency.ID, got.Currency.ID)
+				}
+
+				if got.Currency.Name != wantAccount.Currency.Name {
+					t.Errorf("want Currency.Name %s; got %s", wantAccount.Currency.Name, got.Currency.Name)
+				}
+
+				if got.Currency.Unit != wantAccount.Currency.Unit {
+					t.Errorf("want Currency.Unit %s; got %s", wantAccount.Currency.Unit, got.Currency.Unit)
 				}
 
 				if got.Status != wantAccount.Status {

--- a/pkg/models/mysql/categories_test.go
+++ b/pkg/models/mysql/categories_test.go
@@ -30,6 +30,7 @@ func TestCategoryInsert(t *testing.T) {
 
 		if len(all) != 1 {
 			t.Errorf("want 1 category; got %d", len(all))
+			return
 		}
 
 		category := all[0]

--- a/pkg/models/mysql/testdata/setup.sql
+++ b/pkg/models/mysql/testdata/setup.sql
@@ -1,2 +1,5 @@
 TRUNCATE TABLE category_types;
 INSERT INTO category_types (id, name) VALUES (1, "income"), (2, "expense");
+
+TRUNCATE TABLE currencies;
+INSERT INTO currencies (id, name, unit) VALUES (1, "Euro", "€");

--- a/pkg/models/mysql/testdata/teardown.sql
+++ b/pkg/models/mysql/testdata/teardown.sql
@@ -1,4 +1,5 @@
-TRUNCATE TABLE users;
+TRUNCATE TABLE accounts;
 TRUNCATE TABLE auth_sessions;
 TRUNCATE TABLE categories;
 TRUNCATE TABLE category_types;
+TRUNCATE TABLE users;

--- a/pkg/models/mysql/testdata/teardown.sql
+++ b/pkg/models/mysql/testdata/teardown.sql
@@ -2,4 +2,5 @@ TRUNCATE TABLE accounts;
 TRUNCATE TABLE auth_sessions;
 TRUNCATE TABLE categories;
 TRUNCATE TABLE category_types;
+TRUNCATE TABLE currencies;
 TRUNCATE TABLE users;


### PR DESCRIPTION
Add `/accounts` endpoint to return the list of user's accounts.

## Request example

```
curl -XGET -k -H 'Authorization: Bearer <YOUR_TOKEN>' -H "Content-type: application/json" 'https://localhost:8080/accounts'
```

## Response example

```json
{
   "accounts" : [
      {
         "balance" : 5919.85,
         "currency" : {
            "id" : 2,
            "name" : "EUR",
            "unit" : "€"
         },
         "id" : 1,
         "name" : "Cash",
         "show_in_summary" : true,
         "status" : "active"
      },
      {
         "balance" : 500,
         "currency" : {
            "id" : 1,
            "name" : "USD",
            "unit" : "$"
         },
         "id" : 2,
         "name" : "Cash",
         "show_in_summary" : false,
         "status" : "active"
      }
   ],
   "metadata" : {
      "current_page" : 1,
      "first_page" : 1,
      "last_page" : 1,
      "page_size" : 20,
      "total_records" : 2
   }
}
```